### PR TITLE
Changed prompt and about in language detection demo

### DIFF
--- a/demos/application/language_detect.py
+++ b/demos/application/language_detect.py
@@ -24,7 +24,9 @@ def entrance(request):
         }]
     properties = { 'title' : 'Language Detection',
                    'template': {'type': 'text',
-                                'caption': 'Enter a sentence to classify'},
+                                'caption': 'Currently works for 5 languages: ' +
+                                           'English, Greek, German, Italian and Spanish.' +
+                                           '<p>Enter a sentence to classify</p>'},
                    'panels': [
                        {
                            'panel_name': 'arguments',
@@ -34,7 +36,12 @@ def entrance(request):
                        {
                            'panel_name': 'about',
                            'panel_label': 'About',
-                           'panel_property': 'van51',
+                           'panel_property': 'Language detection demo developed using the ' +
+                                             '<b>HashedDocDotFeatures</b> class of <b>Shogun</b> ' +
+                                             'for the document representation and the '+
+                                             '<b>MulticlassLibLinear</b> for the ' +
+                                             'classification. Trained on ' +
+                                             '30000 documents in total. <br>By van51',
                         }
                     ]
                  }

--- a/templates/common/about.html
+++ b/templates/common/about.html
@@ -1,1 +1,1 @@
-{{ panel.panel_property }}
+{{ panel.panel_property|safe|escape }}

--- a/templates/common/text.js
+++ b/templates/common/text.js
@@ -1,2 +1,2 @@
-$("<p><b>{{ template.caption }}<b></p>").appendTo(".span9")
+$("<p><b>{{ template.caption|safe|escape }}<b></p>").appendTo(".span9")
 $("<textarea id='text' style='font-size: 25px;height: 500px; width: 660px;'></textarea>").appendTo(".span9");


### PR DESCRIPTION
@sonney2k: Changed the message of the language detection demo to state the available languages and the about to mention the classes used. This is what it looks like currently : https://dl.dropboxusercontent.com/u/23851310/Screenshot-shogun-demo.png. If you want something changed let me know.
@ZhengyangL: If you don't approve of the way I bypassed autoescaping and you have another way for disabling it let me know!

On another note, I was thinking that maybe when the documentation on the site is updated we could link classes from the about to the site and/or the authors to their personal webpage or github.
